### PR TITLE
feat: add option to fail builds on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,13 @@ Emit found warnings. This is enabled by default.
 
 Emit found warnings as errors when enabled. This is disabled by default.
 
+### `failOnError`
+
+- Type: `boolean`
+- Default: `false`
+
+Fail build when there are any errors. This is disabled by default.
+
 ## FAQ
 
 <details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -217,6 +217,13 @@ Stylelint 路径，用于校验文件。底层使用使用 [dynamic import](http
 
 将发现的警告作为错误输出。默认禁用。
 
+### `failOnError`
+
+- 类型：`boolean`
+- 默认值：`false`
+
+出现任何错误时构建失败。默认禁用。
+
 ## FAQ
 
 <details>

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,6 +226,14 @@ export interface StylelintPluginOptions extends StylelintLinterOptions {
    * @default false
    */
   emitWarningAsError: boolean;
+  /**
+   * Fail build when there are any errors. This is disabled by default.
+   *
+   * 出现任何错误时构建失败。默认禁用。
+   *
+   * @default false
+   */
+  failOnError: boolean;
 }
 export type StylelintPluginUserOptions = Partial<StylelintPluginOptions>;
 


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Thank you for contributing!
感谢你的贡献！

Before submitting the PR, please make sure you do the following:
在提交PR之前，请确保你做到以下几点：

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

When there are errors from stylelint, add an option to fail builds.

Currently, stylelint errors are emiited, but they do not have the capability to fail builds. It would be nice to be able to fail builds, similar to what [`stylelint-webpack-plugin`](https://github.com/webpack-contrib/stylelint-webpack-plugin#failonerror) provides.

### Linked Issues 关联的 Issues

https://github.com/nuxt-modules/stylelint/issues/89

### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->

Might need help to refine the Chinese translation if it can be better.